### PR TITLE
test(e2e): update to add approval comment workflow for e2e trigger

### DIFF
--- a/.github/workflows/approval-comment.yaml
+++ b/.github/workflows/approval-comment.yaml
@@ -1,0 +1,13 @@
+name: ApprovalComment
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  approval-comment:
+    if: startsWith(github.event.review.body, '/e2e')
+    runs-on: ubuntu-latest
+    steps:
+      - name: run e2e
+        run: |
+          echo "run e2e"

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -3,14 +3,14 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request_review: # TODO(charliedmcb): come back to this and factor out the E2E trigger like AWS and clean it up
-    types: [submitted]
+  workflow_run:
+    workflows: [ApprovalComment]
+    types: [completed]
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout
 jobs:
   e2e-matrix:
-    if: github.event_name != 'pull_request_review' || startsWith(github.event.review.body ,'/test')
     uses: ./.github/workflows/e2e-matrix.yaml
     secrets:
       E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request_review: # TODO(charliedmcb): come back to this and factor out the E2E trigger like AWS and clean it up
+    types: [submitted]
   workflow_run:
     workflows: [ApprovalComment]
     types: [completed]
@@ -11,6 +13,7 @@ permissions:
   contents: read  # This is required for actions/checkout
 jobs:
   e2e-matrix:
+    if: github.event_name != 'pull_request_review' || startsWith(github.event.review.body ,'/test')
     uses: ./.github/workflows/e2e-matrix.yaml
     secrets:
       E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Currently for PR check-in the E2E suite is run via an approval comment directly for the e2e trigger workflow.

This works to test things, but overall has some quality of life issues, as if another approval comes in the trigger will be checked again, un-linking the previous e2e run from the PR regardless of if a new E2E suite run was requested or not.

This PR is step one of two meant to break apart the approval comment check so that the E2E suite run will not be overridden by a new review. This one added the new trigger scenario. Another follow up will be made once tested to remove the old trigger.

**How was this change tested?**
Not able to test since this trigger only works when in the default branch. Due to this I'm only adding the new trigger, and not removing the old one. Once we've tested that it works correctly in the `main` branch than I'll remove the old trigger scenario.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
