### PR TITLE
chore(armclient): removing 429 sdk retries in favor of controller retries

### DIFF
--- a/pkg/utils/opts/armopts.go
+++ b/pkg/utils/opts/armopts.go
@@ -34,6 +34,10 @@ func DefaultArmOpts() *arm.ClientOptions {
 
 func DefaultRetryOpts() policy.RetryOptions {
 	return policy.RetryOptions{
+		// MaxRetries specifies the maximum number of attempts a failed operation will be retried
+		// before producing an error.
+		// The default value is three.  A value less than zero means one try and no retries.
+		// See Reference here: https://github.com/Azure/azure-sdk-for-go/blob/v61.4.0/sdk/azcore/policy/policy.go#L73
 		MaxRetries: -1,
 	}
 }

--- a/pkg/utils/opts/armopts.go
+++ b/pkg/utils/opts/armopts.go
@@ -18,7 +18,6 @@ package opts
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -35,21 +34,7 @@ func DefaultArmOpts() *arm.ClientOptions {
 
 func DefaultRetryOpts() policy.RetryOptions {
 	return policy.RetryOptions{
-		MaxRetries: 20,
-		// Note the default retry behavior is exponential backoff
-		RetryDelay: time.Second * 5,
-		// TODO: bsoghigian: Investigate if we want to leverage some of the status codes other than the defaults.
-		// the defaults are // StatusCodes specifies the HTTP status codes that indicate the operation should be retried.
-		// A nil slice will use the following values.
-		//   http.StatusRequestTimeout      408
-		//   http.StatusTooManyRequests     429
-		//   http.StatusInternalServerError 500
-		//   http.StatusBadGateway          502
-		//   http.StatusServiceUnavailable  503
-		//   http.StatusGatewayTimeout      504
-		// Specifying values will replace the default values.
-		// Specifying an empty slice will disable retries for HTTP status codes.
-		// StatusCodes: nil,
+		MaxRetries: -1,
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Karpenter is a reconciler, and will retry the scale up or delete request if it fails. Also note it only retries on 429 and some other options by default. 


Instead of retrying with SDK we should retry with karpenter, and if we need additional retry flexiblity with backoff for throttling aim to get this change into karpenter core. 

**How was this change tested?**
Scale up scale down 
make az-presubmit 
e2etests

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
