### PR TITLE
test(e2e): change to have the ApprovalComment only trigger e2e suite on success

### DIFF
--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: read  # This is required for actions/checkout
 jobs:
   e2e-matrix:
-    if: (github.event_name != 'pull_request_review' && github.event_name != 'workflow_run') || (github.event_name != 'pull_request_review' && startsWith(github.event.review.body ,'/test')) || (github.event_name != 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    if: (github.event_name != 'pull_request_review' && github.event_name != 'workflow_run') || (github.event_name == 'pull_request_review' && startsWith(github.event.review.body ,'/test')) || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     uses: ./.github/workflows/e2e-matrix.yaml
     secrets:
       E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: read  # This is required for actions/checkout
 jobs:
   e2e-matrix:
-    if: github.event_name != 'pull_request_review' || startsWith(github.event.review.body ,'/test')
+    if: (github.event_name != 'pull_request_review' && github.event_name != 'workflow_run') || (github.event_name != 'pull_request_review' && startsWith(github.event.review.body ,'/test')) || (github.event_name != 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     uses: ./.github/workflows/e2e-matrix.yaml
     secrets:
       E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Currently the ApprovalComment workflow will trigger the e2e suite even on a skipped status. We only want the workflow to be triggered on a successful run status. This PR is meant to fix it.

**How was this change tested?**
Sadly workflow changes need to be committed into the mainline to get executed. Will test immediately afterwards.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
