### PR TITLE
test(e2e): add check for workflow_run success on e2e matrix trigger

### DIFF
--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -12,6 +12,7 @@ permissions:
   statuses: write # ./.github/actions/commit-status/*
 jobs:
   resolve:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/resolve-args.yaml
   e2e-matrix:
     needs: [resolve]


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Forgot to add a check for the workflow_run success of ApprovalComment within MatrixTrigger. 

This meant that runs that should have been getting skipped where failing here instead. This should fix it.

**How was this change tested?**
Tested on my fork, and got expected behavior:
https://github.com/charliedmcb/karpenter/actions/runs/6817129771
![image](https://github.com/Azure/karpenter/assets/33269602/2e507649-b715-485d-92dc-20615bd46998)
https://github.com/charliedmcb/karpenter/pull/2#pullrequestreview-1723448973
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
