### PR TITLE
test(e2e): fix checkout in e2e test workflow to test the PR's branch

### DIFF
--- a/.github/actions/e2e/cleanup/action.yaml
+++ b/.github/actions/e2e/cleanup/action.yaml
@@ -22,10 +22,15 @@ inputs:
   acr_name:
     description: "Name of the acr holding the karpenter image"
     required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out"
+    required: false
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.git_ref }}
     - name: az login
       uses: azure/login@v1
       with:

--- a/.github/actions/e2e/create-acr/action.yaml
+++ b/.github/actions/e2e/create-acr/action.yaml
@@ -16,10 +16,15 @@ inputs:
   acr_name:
     description: "Name of the acr holding the karpenter image"
     required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out"
+    required: false
 runs:
   using: "composite"
   steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
+    with:
+      ref: ${{ inputs.git_ref }}
   - name: az login
     uses: azure/login@v1
     with:

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -26,10 +26,15 @@ inputs:
   acr_name:
     description: "Name of the acr holding the karpenter image"
     required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out"
+    required: false
 runs:
   using: "composite"
   steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
+    with:
+      ref: ${{ inputs.git_ref }}
   - name: az login
     uses: azure/login@v1
     with:

--- a/.github/actions/e2e/dump-logs/action.yaml
+++ b/.github/actions/e2e/dump-logs/action.yaml
@@ -16,10 +16,15 @@ inputs:
   cluster_name:
     description: 'Name of the cluster'
     required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out"
+    required: false
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
+    with:
+      ref: ${{ inputs.git_ref }}
     - name: az login
       uses: azure/login@v1
       with:

--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -22,10 +22,15 @@ inputs:
   acr_name:
     description: "Name of the acr holding the karpenter image"
     required: true
+  git_ref:
+    description: "The git commit, tag, or branch to check out"
+    required: false
 runs:
   using: "composite"
   steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
+    with:
+      ref: ${{ inputs.git_ref }}
   - name: az login
     uses: azure/login@v1
     with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,7 +34,9 @@ jobs:
     env:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.E2E_SUBSCRIPTION_ID }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git_ref }}
       - if: always() && github.event_name == 'workflow_run'
         uses: ./.github/actions/commit-status/start
         with:
@@ -72,6 +74,7 @@ jobs:
           subscription-id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
           resource_group: ${{ env.RG_NAME }}
           acr_name: ${{ env.ACR_NAME }}
+          git_ref: ${{ inputs.git_ref }}
       - name: add jitter on cluster creation
         run: |
           # Creating jitter so that we can stagger cluster creation to avoid throttling
@@ -91,6 +94,7 @@ jobs:
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           acr_name: ${{ env.ACR_NAME }}
+          git_ref: ${{ inputs.git_ref }}
       - name: build and publish karpenter
         shell: bash
         run: AZURE_ACR_NAME=${{ env.ACR_NAME }} make az-build
@@ -103,6 +107,7 @@ jobs:
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           acr_name: ${{ env.ACR_NAME }}
+          git_ref: ${{ inputs.git_ref }}
       - name: run the ${{ inputs.suite }} test suite
         if: inputs.suite != 'Nonbehavioral'
         run: |
@@ -117,6 +122,7 @@ jobs:
           subscription-id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
+          git_ref: ${{ inputs.git_ref }}
       - name: cleanup resources
         uses: ./.github/actions/e2e/cleanup
         if: always()
@@ -128,6 +134,7 @@ jobs:
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           acr_name: ${{ env.ACR_NAME }}
+          git_ref: ${{ inputs.git_ref }}
       - if: always() && github.event_name == 'workflow_run'
         uses: ./.github/actions/commit-status/end
         with:

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -63,8 +63,6 @@ var _ = Describe("Drift", func() {
 	BeforeEach(func() {
 		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 
-		panic("this should fail")
-
 		nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirement{{
 			Key:      v1.LabelInstanceTypeStable,
 			Operator: v1.NodeSelectorOpIn,

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -63,6 +63,8 @@ var _ = Describe("Drift", func() {
 	BeforeEach(func() {
 		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 
+		panic("this should fail")
+
 		nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirement{{
 			Key:      v1.LabelInstanceTypeStable,
 			Operator: v1.NodeSelectorOpIn,


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Noticed in some of my testing that the E2E workflows were no longer pointing at the PR test branch, and instead pointing at `main`.

See this PR:
https://github.com/Azure/karpenter/pull/21
with a panic in the drift test suite:
![image](https://github.com/Azure/karpenter/assets/33269602/675bf3bd-9035-40ae-959d-7d1a910cf094)
Passing the drift test:
![image](https://github.com/Azure/karpenter/assets/33269602/312c81dc-18cd-404e-b7ae-5f7efae11ce0)

 This PR is changing the workflows to ensure they are checking out the intended branch for testing.
 
**How was this change tested?**
None. Needs to be checked into `main`
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
