### PR TITLE
test(e2e): allow for manual triggering of E2E suite

### DIFF
--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -17,6 +17,10 @@ on:
         required: true
       E2E_SUBSCRIPTION_ID:
         required: true
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        type: string
 jobs:
   initialize-generative-params:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,16 @@
 name: E2E
 on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        type: string
+      suite:
+        type: string
+        required: true
+      hash:
+        type: string
+        description: "suffix to use on the Azure resources"
+        required: true
   workflow_call:
     inputs:
     #   region:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Currently there is no way to test within the github action workflows a new E2E test suite. 

I'd like to be able to have it automatically pick up the change to the set of test suites and use that. However, the workflows are being run via their state on the `main` branch. This solution is meant as an alternative solution by allowing a developer to trigger a e2e suite run, and then they can share the link within their PR description.

**How was this change tested?**
Nothing additional
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
