### PR TITLE
test(e2e): fix indentation for dump logs

### DIFF
--- a/.github/actions/e2e/dump-logs/action.yaml
+++ b/.github/actions/e2e/dump-logs/action.yaml
@@ -25,32 +25,32 @@ runs:
   - uses: actions/checkout@v4
     with:
       ref: ${{ inputs.git_ref }}
-    - name: az login
-      uses: azure/login@v1
-      with:
-        client-id: ${{ inputs.client-id }}
-        tenant-id: ${{ inputs.tenant-id }}
-        subscription-id: ${{ inputs.subscription-id }}
-    - name: az set sub
-      shell: bash
-      run: az account set --subscription ${{ inputs.subscription-id }}
-    - name: controller-logs
-      shell: bash
-      run: |
-        echo "step: controller-logs"
-        AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
-        POD_NAME=$(kubectl get pods -n karpenter --no-headers -o custom-columns=":metadata.name" | tail -n 1)
-        echo "logs from pod ${POD_NAME}"
-        kubectl logs "${POD_NAME}" -n karpenter -c controller
-    - name: describe-karpenter-pods
-      shell: bash
-      run: |
-        echo "step: describe-karpenter-pods"
-        AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
-        kubectl describe pods -n karpenter
-    - name: describe-nodes
-      shell: bash
-      run: |
-        echo "step: describe-nodes"
-        AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
-        kubectl describe nodes
+  - name: az login
+    uses: azure/login@v1
+    with:
+      client-id: ${{ inputs.client-id }}
+      tenant-id: ${{ inputs.tenant-id }}
+      subscription-id: ${{ inputs.subscription-id }}
+  - name: az set sub
+    shell: bash
+    run: az account set --subscription ${{ inputs.subscription-id }}
+  - name: controller-logs
+    shell: bash
+    run: |
+      echo "step: controller-logs"
+      AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
+      POD_NAME=$(kubectl get pods -n karpenter --no-headers -o custom-columns=":metadata.name" | tail -n 1)
+      echo "logs from pod ${POD_NAME}"
+      kubectl logs "${POD_NAME}" -n karpenter -c controller
+  - name: describe-karpenter-pods
+    shell: bash
+    run: |
+      echo "step: describe-karpenter-pods"
+      AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
+      kubectl describe pods -n karpenter
+  - name: describe-nodes
+    shell: bash
+    run: |
+      echo "step: describe-nodes"
+      AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
+      kubectl describe nodes

--- a/.github/actions/e2e/dump-logs/action.yaml
+++ b/.github/actions/e2e/dump-logs/action.yaml
@@ -25,32 +25,32 @@ runs:
   - uses: actions/checkout@v4
     with:
       ref: ${{ inputs.git_ref }}
-  - name: az login
-    uses: azure/login@v1
-    with:
-      client-id: ${{ inputs.client-id }}
-      tenant-id: ${{ inputs.tenant-id }}
-      subscription-id: ${{ inputs.subscription-id }}
-  - name: az set sub
-    shell: bash
-    run: az account set --subscription ${{ inputs.subscription-id }}
-  - name: controller-logs
-    shell: bash
-    run: |
-      echo "step: controller-logs"
-      AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
-      POD_NAME=$(kubectl get pods -n karpenter --no-headers -o custom-columns=":metadata.name" | tail -n 1)
-      echo "logs from pod ${POD_NAME}"
-      kubectl logs "${POD_NAME}" -n karpenter -c controller
-  - name: describe-karpenter-pods
-    shell: bash
-    run: |
-      echo "step: describe-karpenter-pods"
-      AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
-      kubectl describe pods -n karpenter
-  - name: describe-nodes
-    shell: bash
-    run: |
-      echo "step: describe-nodes"
-      AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
-      kubectl describe nodes
+    - name: az login
+      uses: azure/login@v1
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        subscription-id: ${{ inputs.subscription-id }}
+    - name: az set sub
+      shell: bash
+      run: az account set --subscription ${{ inputs.subscription-id }}
+    - name: controller-logs
+      shell: bash
+      run: |
+        echo "step: controller-logs"
+        AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
+        POD_NAME=$(kubectl get pods -n karpenter --no-headers -o custom-columns=":metadata.name" | tail -n 1)
+        echo "logs from pod ${POD_NAME}"
+        kubectl logs "${POD_NAME}" -n karpenter -c controller
+    - name: describe-karpenter-pods
+      shell: bash
+      run: |
+        echo "step: describe-karpenter-pods"
+        AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
+        kubectl describe pods -n karpenter
+    - name: describe-nodes
+      shell: bash
+      run: |
+        echo "step: describe-nodes"
+        AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-creds
+        kubectl describe nodes

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -63,8 +63,6 @@ var _ = Describe("Drift", func() {
 	BeforeEach(func() {
 		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 
-		panic("this should fail")
-
 		nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirement{{
 			Key:      v1.LabelInstanceTypeStable,
 			Operator: v1.NodeSelectorOpIn,

--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -63,6 +63,8 @@ var _ = Describe("Drift", func() {
 	BeforeEach(func() {
 		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 
+		panic("this should fail")
+
 		nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirement{{
 			Key:      v1.LabelInstanceTypeStable,
 			Operator: v1.NodeSelectorOpIn,


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
@tallaxes noticed that the log dump on failure was not working.

Looking into it I noticed that the action was not indented correctly. This PR fixes the indentation, and the issues with the log dump.

**How was this change tested?**
I ran the E2E pipeline with a guaranteed failure [in drift] with the log dumps current status in main, which caused it to fail:
https://github.com/Azure/karpenter/actions/runs/6829122309/job/18574667354
Then I ran it with the guaranteed failure [in drift] with the log dump indentation fixed:
https://github.com/Azure/karpenter/actions/runs/6829114912
The fixed indentation executed correctly.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
