### PR TITLE
test(e2e): add location option to the e2e pipeline

### DIFF
--- a/.github/actions/e2e/create-acr/action.yaml
+++ b/.github/actions/e2e/create-acr/action.yaml
@@ -19,6 +19,10 @@ inputs:
   git_ref:
     description: "The git commit, tag, or branch to check out"
     required: false
+  location:
+    type: string
+    description: "the azure location to run the e2e test in"
+    default: "westus2"
 runs:
   using: "composite"
   steps:
@@ -36,4 +40,4 @@ runs:
     run: az account set --subscription ${{ inputs.subscription-id }}
   - name: create ACR
     shell: bash
-    run: AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} AZURE_ACR_NAME=${{ inputs.acr_name }} make az-mkacr
+    run: AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} AZURE_ACR_NAME=${{ inputs.acr_name }} AZURE_LOCATION=${{ inputs.location }} make az-mkacr

--- a/.github/actions/e2e/create-cluster/action.yaml
+++ b/.github/actions/e2e/create-cluster/action.yaml
@@ -14,9 +14,6 @@ inputs:
   subscription-id:
     description: 
     required: true
-  # region:
-  #   description: "Region to create aks cluster"
-  #   required: true
   resource_group:
     description: "Name of the resource group to create the cluster within"
     required: true
@@ -29,6 +26,10 @@ inputs:
   git_ref:
     description: "The git commit, tag, or branch to check out"
     required: false
+  location:
+    type: string
+    description: "the azure location to run the e2e test in"
+    default: "westus2"
 runs:
   using: "composite"
   steps:
@@ -46,7 +47,7 @@ runs:
     run: az account set --subscription ${{ inputs.subscription-id }}
   - name: create cluster
     shell: bash
-    run: AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} AZURE_ACR_NAME=${{ inputs.acr_name }} make az-mkaks-cilium
+    run: AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} AZURE_ACR_NAME=${{ inputs.acr_name }} AZURE_LOCATION=${{ inputs.location }} make az-mkaks-cilium
   - name: az login 2
     uses: azure/login@v1
     with:
@@ -55,4 +56,4 @@ runs:
       subscription-id: ${{ inputs.subscription-id }}
   - name: update azure perms
     shell: bash
-    run: AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-perm
+    run: AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} AZURE_LOCATION=${{ inputs.location }} make az-perm

--- a/.github/actions/e2e/install-karpenter/action.yaml
+++ b/.github/actions/e2e/install-karpenter/action.yaml
@@ -25,6 +25,10 @@ inputs:
   git_ref:
     description: "The git commit, tag, or branch to check out"
     required: false
+  location:
+    type: string
+    description: "the azure location to run the e2e test in"
+    default: "westus2"
 runs:
   using: "composite"
   steps:
@@ -42,7 +46,7 @@ runs:
     run: az account set --subscription ${{ inputs.subscription-id }}
   - name: patch skaffold and cilium
     shell: bash
-    run: AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} make az-patch-skaffold-azureoverlay
+    run: AZURE_CLUSTER_NAME=${{ inputs.cluster_name }} AZURE_RESOURCE_GROUP=${{ inputs.resource_group }} AZURE_LOCATION=${{ inputs.location }} make az-patch-skaffold-azureoverlay
   - name: deploy karpenter to cluster
     shell: bash
     run: AZURE_ACR_NAME=${{ inputs.acr_name }} make az-run

--- a/.github/workflows/e2e-matrix-trigger.yaml
+++ b/.github/workflows/e2e-matrix-trigger.yaml
@@ -1,6 +1,11 @@
 name: E2EMatrixTrigger
 on:
   workflow_dispatch:
+    inputs:
+      location:
+        type: string
+        description: "the azure location to run the e2e test in"
+        default: "westus2"
   push:
     branches: [main]
   workflow_run:
@@ -19,6 +24,7 @@ jobs:
     uses: ./.github/workflows/e2e-matrix.yaml
     with:
       git_ref: ${{ needs.resolve.outputs.GIT_REF }}
+      location: ${{ inputs.location || 'westus2' }}
     secrets:
       E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}
       E2E_TENANT_ID: ${{ secrets.E2E_TENANT_ID }}

--- a/.github/workflows/e2e-matrix.yaml
+++ b/.github/workflows/e2e-matrix.yaml
@@ -4,9 +4,10 @@ on:
     inputs:
       git_ref:
         type: string
-  #     region:
-  #       type: string
-  #       default: "us-east-2"
+      location:
+        type: string
+        description: "the azure location to run the e2e test in"
+        default: "westus2"
   #     k8s_version:
   #       type: string
   #       default: "1.27"
@@ -39,7 +40,7 @@ jobs:
       git_ref: ${{ inputs.git_ref }}
       suite: ${{ matrix.suite }}
       hash: ${{ needs.initialize-generative-params.outputs.E2E_HASH }}
-  #     region: ${{ inputs.region }}
+      location: ${{ inputs.location }}
   #     k8s_version: ${{ inputs.k8s_version }}
     secrets:
       E2E_CLIENT_ID: ${{ secrets.E2E_CLIENT_ID }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,9 +2,6 @@ name: E2E
 on:
   workflow_call:
     inputs:
-    #   region:
-    #     type: string
-    #     default: "us-east-2"
       git_ref:
         type: string
       suite:
@@ -13,6 +10,10 @@ on:
       hash:
         type: string
         required: true
+      location:
+        type: string
+        description: "the azure location to run the e2e test in"
+        default: "westus2"
     #   k8s_version:
     #     type: string
     #     default: "1.27"
@@ -75,6 +76,7 @@ jobs:
           resource_group: ${{ env.RG_NAME }}
           acr_name: ${{ env.ACR_NAME }}
           git_ref: ${{ inputs.git_ref }}
+          location: ${{ inputs.location }}
       - name: add jitter on cluster creation
         run: |
           # Creating jitter so that we can stagger cluster creation to avoid throttling
@@ -90,11 +92,11 @@ jobs:
           client-id: ${{ secrets.E2E_CLIENT_ID }}
           tenant-id: ${{ secrets.E2E_TENANT_ID }}
           subscription-id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
-          # region: westus2
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           acr_name: ${{ env.ACR_NAME }}
           git_ref: ${{ inputs.git_ref }}
+          location: ${{ inputs.location }}
       - name: build and publish karpenter
         shell: bash
         run: AZURE_ACR_NAME=${{ env.ACR_NAME }} make az-build
@@ -108,6 +110,7 @@ jobs:
           cluster_name: ${{ env.CLUSTER_NAME }}
           acr_name: ${{ env.ACR_NAME }}
           git_ref: ${{ inputs.git_ref }}
+          location: ${{ inputs.location }}
       - name: run the ${{ inputs.suite }} test suite
         if: inputs.suite != 'Nonbehavioral'
         run: |
@@ -130,7 +133,6 @@ jobs:
           client-id: ${{ secrets.E2E_CLIENT_ID }}
           tenant-id: ${{ secrets.E2E_TENANT_ID }}
           subscription-id: ${{ secrets.E2E_SUBSCRIPTION_ID }}
-          # region: westus2
           resource_group: ${{ env.RG_NAME }}
           cluster_name: ${{ env.CLUSTER_NAME }}
           acr_name: ${{ env.ACR_NAME }}

--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -25,7 +25,7 @@ az-mkacr: az-mkrg ## Create test ACR
 	az acr login  --name $(AZURE_ACR_NAME)
 
 az-mkaks: az-mkacr ## Create test AKS cluster (with --vm-set-type AvailabilitySet for compatibility with standalone VMs)
-	az aks create          --name $(AZURE_CLUSTER_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --attach-acr $(AZURE_ACR_NAME) \
+	az aks create          --name $(AZURE_CLUSTER_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --attach-acr $(AZURE_ACR_NAME) --location $(AZURE_LOCATION) \
 		--enable-managed-identity --node-count 3 --generate-ssh-keys --vm-set-type AvailabilitySet -o none
 	az aks get-credentials --name $(AZURE_CLUSTER_NAME) --resource-group $(AZURE_RESOURCE_GROUP) --overwrite-existing
 	skaffold config set default-repo $(AZURE_ACR_NAME).azurecr.io/karpenter


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Wanting to give us more flexibility for manual e2e testing, and/or any additional automated testing by opening up the ability to specify the location for a e2e test to be run in.

**How was this change tested?**
Here is the branch specific E2E test, which is also targeting `eastus`:
https://github.com/Azure/karpenter/actions/runs/6895118672/job/18758391880
Note: the failures are within GPU is an expected current quota issue, and PVC is flaky atm. With the overall confirmation of the tests running in the given region and the rest of the check-in tests passing, I'm completing this.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
