### PR TITLE
test(e2e): fix drift E2E to use ReplaceRequirements

### DIFF
--- a/test/suites/drift/suite_test.go
+++ b/test/suites/drift/suite_test.go
@@ -63,11 +63,11 @@ var _ = Describe("Drift", func() {
 	BeforeEach(func() {
 		env.ExpectSettingsOverridden(v1.EnvVar{Name: "FEATURE_GATES", Value: "Drift=true"})
 
-		nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirement{{
+		test.ReplaceRequirements(nodePool, v1.NodeSelectorRequirement{
 			Key:      v1.LabelInstanceTypeStable,
 			Operator: v1.NodeSelectorOpIn,
 			Values:   []string{"Standard_DS2_v2"},
-		}}
+		})
 
 		// Add a do-not-disrupt pod so that we can check node metadata before we disrupt
 		pod = test.Pod(test.PodOptions{


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Drift E2E has been a bit flaky with overprovisioning. While investigating I noticed that there was an issue where the drift E2E test was using spot instances:
![image](https://github.com/Azure/karpenter/assets/33269602/de037ee4-fe4b-4639-9a76-77678bacc969)

This should not be the case. We should be using on-demand for drift.

Found there was an issue where we were replacing the Requirements on the nodepool, rather than using the override func. 

**How was this change tested?**
Nothing additional.
*

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
