### PR TITLE
chore: increase maxPods to 250

### DIFF
--- a/examples/v1beta1/general-purpose.yaml
+++ b/examples/v1beta1/general-purpose.yaml
@@ -24,6 +24,8 @@ spec:
         - key: karpenter.azure.com/sku-family
           operator: In
           values: [D]
+      kubelet:
+        maxPods: 250
       nodeClassRef:
         name: default
 ---


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**

As the cluster created via the `make az-all` command comes with the setting `maxPods: 250` it would be good to align on that and set the same on the example general-purpose nodePool.

**How was this change tested?**

* NodePool config file was updated and the inflate example deployment was manually scaled up.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
