### PR TITLE
chore: change tags to karpenter.azure.com_cluster

### DIFF
--- a/Makefile-az.mk
+++ b/Makefile-az.mk
@@ -225,7 +225,7 @@ az-perftest1000: ## Test scaling out/in (1000 VMs)
 az-resg: ## List resources in MC rg
 	az resource list -o table -g $(AZURE_RESOURCE_GROUP_MC)
 
-RESK=az resource list --tag=karpenter.sh_nodepool --query "[?resourceGroup=='$(AZURE_RESOURCE_GROUP_MC)']"
+RESK=az resource list --tag=karpenter.azure.com_cluster --query "[?resourceGroup=='$(AZURE_RESOURCE_GROUP_MC)']"
 az-res: ## List resources created by Karpenter
 	$(RESK) -o table
 
@@ -267,7 +267,7 @@ az-node-viewer: ## Watch nodes using eks-node-viewer
 	eks-node-viewer --disable-pricing --node-selector "karpenter.sh/nodepool" # --resources cpu,memory
 
 az-argvmlist: ## List current VMs owned by Karpenter
-	az graph query -q "Resources | where type =~ 'microsoft.compute/virtualmachines' | where resourceGroup == tolower('$(AZURE_RESOURCE_GROUP_MC)') | where tags has_cs 'karpenter.sh_nodepool'" \
+	az graph query -q "Resources | where type =~ 'microsoft.compute/virtualmachines' | where resourceGroup == tolower('$(AZURE_RESOURCE_GROUP_MC)') | where tags has_cs 'karpenter.azure.com_cluster" \
 	--subscriptions $(AZURE_SUBSCRIPTION_ID) \
 	| jq '.data[] | .id'
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->


**Description**

If you run `make az-resc` is does not show all resources created by Karpenter as the `resk` var only show resources with the label `karpenter.sh_nodepool`. But as you can see on [#67 ](https://github.com/Azure/karpenter/issues/67) Ghost Nics for example do not have the labels `karpenter.sh_nodepool` but they do have the labels `karpenter.azure.com_cluster`. So this PR changes the label used by the `resk` call.

It seems also that NICs never get the tag `karpenter.sh_nodepool` assigned.

```
make az-resc
az resource list --tag=karpenter.sh_nodepool --query "[?resourceGroup=='MC_rg-karpenter-pwe-tmp1_aks-karpenter-pwe-tmp1_northeurope']" -o tsv | wc -l
1
```
vs

```
make az-resc
az resource list --tag=karpenter.azure.com_cluster --query "[?resourceGroup=='MC_rg-karpenter-pwe-tmp1_aks-karpenter-pwe-tmp1_northeurope']" -o tsv | wc -l
38
```

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
