### PR TITLE
chore: bump cuda gpu driver version from 525 to 535

### DIFF
--- a/pkg/utils/gpu.go
+++ b/pkg/utils/gpu.go
@@ -23,11 +23,11 @@ import (
 // TODO: Get these from agentbaker
 const (
 	Nvidia470CudaDriverVersion = "cuda-470.82.01"
-	Nvidia525CudaDriverVersion = "cuda-525.85.12"
+	Nvidia535CudaDriverVersion = "cuda-535.54.03"
 	Nvidia535GridDriverVersion = "grid-535.54.03"
 
 	AKSGPUGridSHA = "sha-20ffa2"
-	AKSGPUCudaSHA = "sha-e8873b"
+	AKSGPUCudaSHA = "sha-ff213d"
 )
 
 func GetAKSGPUImageSHA(size string) string {
@@ -146,7 +146,7 @@ func GetGPUDriverVersion(size string) string {
 	if isStandardNCv1(size) {
 		return Nvidia470CudaDriverVersion
 	}
-	return Nvidia525CudaDriverVersion
+	return Nvidia535CudaDriverVersion
 }
 
 func isStandardNCv1(size string) bool {

--- a/pkg/utils/gpu_test.go
+++ b/pkg/utils/gpu_test.go
@@ -55,9 +55,9 @@ func TestGetGPUDriverVersion(t *testing.T) {
 	}{
 		{"GRID Driver - NV Series v5", "standard_nv6ads_a10_v5", Nvidia535GridDriverVersion},
 		{"CUDA Driver - NC Series v1", "standard_nc6s", Nvidia470CudaDriverVersion},
-		{"CUDA Driver - NC Series v2", "standard_nc6s_v2", Nvidia525CudaDriverVersion},
-		{"Unknown SKU", "unknown_sku", Nvidia525CudaDriverVersion},
-		{"CUDA Driver - NC Series v3", "standard_nc6s_v3", Nvidia525CudaDriverVersion},
+		{"CUDA Driver - NC Series v2", "standard_nc6s_v2", Nvidia535CudaDriverVersion},
+		{"Unknown SKU", "unknown_sku", Nvidia535CudaDriverVersion},
+		{"CUDA Driver - NC Series v3", "standard_nc6s_v3", Nvidia535CudaDriverVersion},
 		{"GRID Driver - A10", "standard_nc8ads_a10_v4", Nvidia535GridDriverVersion},
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Recently we bumped the grid drivers, to make them compatible with [v12](https://docs.nvidia.com/deploy/cuda-compatibility/#minor-version-compatibility), we also are bumping the cuda driver version as well
See 
- https://docs.nvidia.com/deploy/cuda-compatibility/#minor-version-compatibility
- https://github.com/Azure/AgentBaker/pull/3950

**How was this change tested?**
- make presubmit
- gpu e2e

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Bumped Cuda Driver version from 525 to 535
```
