### PR TITLE
chore: Small style + usability refactors for new contributors

### DIFF
--- a/pkg/fake/azureresourcegraphapi.go
+++ b/pkg/fake/azureresourcegraphapi.go
@@ -39,7 +39,7 @@ type AzureResourceGraphBehavior struct {
 }
 
 // assert that the fake implements the interface
-var _ instance.AzureResourceGraphAPI = (*AzureResourceGraphAPI)(nil)
+var _ instance.AzureResourceGraphAPI = &AzureResourceGraphAPI{}
 
 type AzureResourceGraphAPI struct {
 	AzureResourceGraphBehavior

--- a/pkg/fake/communityimageversionsapi.go
+++ b/pkg/fake/communityimageversionsapi.go
@@ -30,7 +30,7 @@ type CommunityGalleryImageVersionsAPI struct {
 }
 
 // assert that the fake implements the interface
-var _ imagefamily.CommunityGalleryImageVersionsAPI = (*CommunityGalleryImageVersionsAPI)(nil)
+var _ imagefamily.CommunityGalleryImageVersionsAPI = &CommunityGalleryImageVersionsAPI{}
 
 // NewListPager returns a new pager to return the next page of CommunityGalleryImageVersionsClientListResponse
 func (c *CommunityGalleryImageVersionsAPI) NewListPager(_ string, _ string, _ string, _ *armcompute.CommunityGalleryImageVersionsClientListOptions) *runtime.Pager[armcompute.CommunityGalleryImageVersionsClientListResponse] {

--- a/pkg/fake/networkinterfaceapi.go
+++ b/pkg/fake/networkinterfaceapi.go
@@ -40,7 +40,7 @@ type NetworkInterfacesBehavior struct {
 }
 
 // assert that the fake implements the interface
-var _ instance.NetworkInterfacesAPI = (*NetworkInterfacesAPI)(nil)
+var _ instance.NetworkInterfacesAPI = &NetworkInterfacesAPI{}
 
 type NetworkInterfacesAPI struct {
 	// instance.NetworkInterfacesAPI

--- a/pkg/fake/pricingapi.go
+++ b/pkg/fake/pricingapi.go
@@ -36,6 +36,9 @@ type PricingBehavior struct {
 	ProductsPricePage AtomicPtr[client.ProductsPricePage]
 }
 
+// assert that the fake implements the interface
+var _ client.PricingAPI = &PricingAPI{}
+
 func (p *PricingAPI) Reset() {
 	p.NextError.Reset()
 	p.ProductsPricePage.Reset()

--- a/pkg/fake/virtualmachineextensionsapi.go
+++ b/pkg/fake/virtualmachineextensionsapi.go
@@ -40,7 +40,7 @@ type VirtualMachineExtensionsBehavior struct {
 }
 
 // assert that ComputeAPI implements ARMComputeAPI
-var _ instance.VirtualMachineExtensionsAPI = (*VirtualMachineExtensionsAPI)(nil)
+var _ instance.VirtualMachineExtensionsAPI = &VirtualMachineExtensionsAPI{}
 
 type VirtualMachineExtensionsAPI struct {
 	// instance.VirtualMachineExtensionsAPI

--- a/pkg/fake/virtualmachinesapi.go
+++ b/pkg/fake/virtualmachinesapi.go
@@ -66,7 +66,7 @@ type VirtualMachinesBehavior struct {
 }
 
 // assert that the fake implements the interface
-var _ instance.VirtualMachinesAPI = (*VirtualMachinesAPI)(nil)
+var _ instance.VirtualMachinesAPI = &VirtualMachinesAPI{}
 
 type VirtualMachinesAPI struct {
 	// TODO: document the implications of embedding vs. not embedding the interface here

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -54,10 +54,10 @@ type Operator struct {
 }
 
 func NewOperator(ctx context.Context, operator *operator.Operator) (context.Context, *Operator) {
-	azConfig, err := GetAzConfig()
+	azConfig, err := GetAZConfig()
 	lo.Must0(err, "creating Azure config") // TODO: I assume we prefer this over the cleaner azConfig := lo.Must(GetAzConfig()), as this has a helpful error message?
 
-	azClient, err := instance.CreateAzClient(ctx, azConfig)
+	azClient, err := instance.CreateAZClient(ctx, azConfig)
 	lo.Must0(err, "creating Azure client")
 
 	unavailableOfferingsCache := azurecache.NewUnavailableOfferings()
@@ -125,7 +125,7 @@ func NewOperator(ctx context.Context, operator *operator.Operator) (context.Cont
 	}
 }
 
-func GetAzConfig() (*auth.Config, error) {
+func GetAZConfig() (*auth.Config, error) {
 	cfg, err := auth.BuildAzureConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/providers/instance/azure_client.go
+++ b/pkg/providers/instance/azure_client.go
@@ -132,7 +132,7 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *azure.Environment) 
 	}
 
 	opts := armopts.DefaultArmOpts()
-	extClient, err := armcompute.NewVirtualMachineExtensionsClient(cfg.SubscriptionID, cred, opts)
+	extensionsClient, err := armcompute.NewVirtualMachineExtensionsClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -177,14 +177,11 @@ func NewAZClient(ctx context.Context, cfg *auth.Config, env *azure.Environment) 
 	// TODO Move this over to track 2 when skewer is migrated
 	skuClient := skuclient.NewSkuClient(ctx, cfg, env)
 
-	return &AZClient{
-		networkInterfacesClient:        interfacesClient,
-		virtualMachinesClient:          virtualMachinesClient,
-		virtualMachinesExtensionClient: extClient,
-		azureResourceGraphClient:       azureResourceGraphClient,
-
-		ImageVersionsClient: imageVersionsClient,
-		SKUClient:           skuClient,
-		LoadBalancersClient: loadBalancersClient,
-	}, nil
+	return NewAZClientFromAPI(virtualMachinesClient,
+		azureResourceGraphClient,
+		extensionsClient,
+		interfacesClient,
+		loadBalancersClient,
+		imageVersionsClient,
+		skuClient), nil
 }

--- a/pkg/providers/instance/azure_client.go
+++ b/pkg/providers/instance/azure_client.go
@@ -94,7 +94,7 @@ func NewAZClientFromAPI(
 	}
 }
 
-func CreateAzClient(ctx context.Context, cfg *auth.Config) (*AZClient, error) {
+func CreateAZClient(ctx context.Context, cfg *auth.Config) (*AZClient, error) {
 	// Defaulting env to Azure Public Cloud.
 	env := azure.PublicCloud
 	var err error

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -9,7 +9,7 @@ build:
           paths:
             - '**/*.go'
             - '**/*.gtpl'
-        #flags: ['-tags', 'ccp']
+            #flags: ['-tags', 'ccp']
 manifests:
   helm:
     releases:
@@ -29,10 +29,10 @@ manifests:
               drift: true
             azure:
               clusterName: karpenter
-              clusterEndpoint: https://karpenter-tallaxes-azure-k-26fe00-j3imiwu5.hcp.westus2.staging.azmk8s.io:443
-              kubeletClientTLSBootstrapToken: "<updateme>" # TODO: get this from the cluster
+              clusterEndpoint: "Please run make az-all"
+              kubeletClientTLSBootstrapToken: "Please run make az-all" # TODO: get this from the cluster
               # TODO: autogenerate
-              sshPublicKey: "<updateme>"
+              sshPublicKey: "Please run make az-all"
               networkPlugin: "azure" # TODO: get this from the cluster
               networkPolicy: ""
           replicas: 1 # for better debugging experience
@@ -46,23 +46,23 @@ manifests:
             batchMaxDuration: 10s # 60s is a good value for large runs (500+ nodes)
             env:
               - name: ARM_SUBSCRIPTION_ID
-                value: ""
+                value: "Please run make az-all"
               - name: LOCATION
                 value: westus2
               - name: ARM_USE_MANAGED_IDENTITY_EXTENSION
                 value: "true"
               - name: ARM_USER_ASSIGNED_IDENTITY_ID
-                value: ""
+                value: "Please run make az-all"
               - name: AZURE_NODE_RESOURCE_GROUP
-                value: ""
+                value: "Please run make az-all"
               - name: AZURE_SUBNET_ID # the id of subnet to create network interfaces on
-                value: ""
+                value: "Please run make az-all"
               - name: LEADER_ELECT # disable leader election for better debugging experience
                 value: "false"
               - name: AZURE_VNET_NAME
-                value: ""
+                value: "Please run make az-all"
               - name: AZURE_SUBNET_NAME
-                value: ""
+                value: "Please run make az-all"
                 # disable HTTP/2 to reduce ARM throttling on large-scale tests;
                 # with this in place write (and read) QPS can be increased too
                 #- name: GODEBUG


### PR DESCRIPTION
**Description**
*These changes are based on feedback from @matthchr*

- [x] Update (and as a follow-up git ignore) `skaffold.yaml` so that `make az-all` automated local changes during development are less confusing.
- [x] Style refactors
  - [x] `NewAZClientFromAPI` vs. `NewAZClient`. Maybe one of these should call the other then? `NewAZClient` constructs all the clients + calls `NewAZClientFromAPI`
  - [x] Inconsistent with abbreviation casing (`CreateAzClient` vs. `NewAZClient`)
  - [x] Fakes: `var _ instance.NetworkInterfacesAPI = (*NetworkInterfacesAPI)(nil)` -> 
  `var _ instance.NetworkInterfacesAPI = &NetworkInterfacesAPI{}` 

**How was this change tested?**
* `make presubmit`
* `make az-all`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [ ] No
